### PR TITLE
v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 1.3.0
+- Add `PlayxPlatformVersion` with `newPlatformVersion` and `minPlatformVersion` overrides for Android- and iOS-specific app version checks.
+- Keep `newVersion` and `minVersion` as the effective resolved values in `PlayxVersionUpdateInfo` for backward compatibility.
+- Enhance minimum-version parsing for store descriptions with bracketed, case-insensitive matching and broader version-style support.
+- Improve HTML text formatting utilities and expand automated test coverage across version handling, parsing, results, errors, and datasource utilities.
+
 ## 1.1.0
 - Update packages
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ Future<void> showSimpleUpdateDialog(BuildContext context) async {
       androidPackageName: 'com.your_company.your_app_id', // Your Android package name
       iosBundleId: 'com.your_company.your_app_id',      // Your iOS bundle ID
       minVersion: '1.0.0', // Optional: Sets a minimum required version for a forced update
+      newPlatformVersion: PlayxPlatformVersion(
+        android: '1.2.0',
+        ios: '1.3.0',
+      ),
+      minPlatformVersion: PlayxPlatformVersion(
+        android: '1.1.0',
+        ios: '1.2.0',
+      ),
     ),
     // PlayxUpdateUIOptions: Customize the Flutter UI of the dialog
     uiOptions: PlayxUpdateUIOptions(
@@ -188,6 +196,11 @@ Future<void> checkForUpdateAndShowCustomUI(BuildContext context) async {
       localVersion: '1.0.0',
       // Optional: Provide new app version (bypasses store lookup if provided)
       newVersion: '1.1.0',
+      // Optional: Override versions per platform from a custom backend
+      newPlatformVersion: PlayxPlatformVersion(
+        android: '1.1.0',
+        ios: '1.1.5',
+      ),
       // Optional: Manually override force update status (e.g., forceUpdate: true)
       // If null, it's calculated based on localVersion vs. minVersion
       forceUpdate: true,
@@ -264,6 +277,12 @@ Supported formats are case-insensitive, require square brackets, and allow a few
 The version value itself follows the same styles supported by the package version parser, including multi-part versions like `519.0.0.44.92` and tagged versions like `3.122.764106578.release` or `1.2.3-alpha.1+build.456`.
 
 The package will parse this information and automatically update the `forceUpdate` value of `PlayxVersionUpdateInfo` returned by `checkVersion` accordingly.
+
+### Platform-Specific Version Overrides
+
+If your backend serves different app versions for Android and iOS, use `newPlatformVersion` and `minPlatformVersion`.
+
+These values override `newVersion` and `minVersion` on the current platform only, while `PlayxVersionUpdateInfo.newVersion` and `PlayxVersionUpdateInfo.minVersion` continue to expose the effective resolved values used by the package.
 
 
 -----

--- a/README.md
+++ b/README.md
@@ -254,7 +254,16 @@ Future<void> checkForUpdateAndShowCustomUI(BuildContext context) async {
 
 You can automatically determine if an update should be forced by embedding a minimum version string in your app's Google Play Store or Apple App Store description.
 
-Simply add `[Minimum Version :X.Y.Z]` to the end of your app's store description (e.g., `[Minimum Version :1.5.0]`). The package will parse this information and automatically update the `forceUpdate` value of `PlayxVersionUpdateInfo` returned by `checkVersion` accordingly.
+Supported formats are case-insensitive, require square brackets, and allow a few separator styles, for example:
+
+- `[Minimum Version :1.5.0]`
+- `[Minimum Version: 1.5.0]`
+- `[Minimum Version = 1.5.0]`
+- `[minimum_version:1.5.0]`
+
+The version value itself follows the same styles supported by the package version parser, including multi-part versions like `519.0.0.44.92` and tagged versions like `3.122.764106578.release` or `1.2.3-alpha.1+build.456`.
+
+The package will parse this information and automatically update the `forceUpdate` value of `PlayxVersionUpdateInfo` returned by `checkVersion` accordingly.
 
 
 -----
@@ -743,4 +752,3 @@ For a complete list of all possible errors, refer to the [PlayxVersionUpdateErro
 
 -   [playx_network](https://pub.dev/packages/playx_network) - The network package used internally for version checks.
     
-

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -393,6 +393,14 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
         androidPackageName:
             'io.sourcya.playx.verion.update.example', // Example package name
         iosBundleId: 'com.apple.shortcuts', // Example bundle ID
+        newPlatformVersion: const PlayxPlatformVersion(
+          android: '1.0.1',
+          ios: '1.0.2',
+        ),
+        minPlatformVersion: const PlayxPlatformVersion(
+          android: '1.0.0',
+          ios: '1.0.1',
+        ),
       ),
     );
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -283,18 +283,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -413,7 +413,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.0"
+    version: "1.2.0"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -591,10 +591,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:

--- a/lib/playx_version_update.dart
+++ b/lib/playx_version_update.dart
@@ -1,6 +1,7 @@
 export 'package:playx_version_update/src/core/model/in_app_updates/playx_app_update_availability.dart';
 export 'package:playx_version_update/src/core/model/in_app_updates/playx_app_update_type.dart';
 export 'package:playx_version_update/src/core/model/in_app_updates/playx_download_info.dart';
+export 'package:playx_version_update/src/core/model/playx_platform_version.dart';
 export 'package:playx_version_update/src/core/model/playx_version_update_info.dart';
 export 'package:playx_version_update/src/core/model/result/playx_version_update_error.dart';
 export 'package:playx_version_update/src/core/model/result/playx_version_update_result.dart';

--- a/lib/src/core/model/options/playx_update_options.dart
+++ b/lib/src/core/model/options/playx_update_options.dart
@@ -1,3 +1,5 @@
+import 'package:playx_version_update/src/core/model/playx_platform_version.dart';
+
 /// Configuration for version checking.
 class PlayxUpdateOptions {
   /// The current version of the app. If not provided, it's fetched from `package_info_plus`.
@@ -15,6 +17,16 @@ class PlayxUpdateOptions {
   /// If the app's `localVersion` is less than `minVersion`, the result will
   /// indicate a forced update is required, **unless `forceUpdate` is explicitly set to `false`**.
   final String? minVersion;
+
+  /// Platform-specific new app versions, typically provided by a custom backend.
+  ///
+  /// On the current platform, this value overrides [newVersion] when provided.
+  final PlayxPlatformVersion? newPlatformVersion;
+
+  /// Platform-specific minimum required app versions, typically provided by a custom backend.
+  ///
+  /// On the current platform, this value overrides [minVersion] when provided.
+  final PlayxPlatformVersion? minPlatformVersion;
 
   /// Manually set the force update status.
   ///
@@ -44,6 +56,8 @@ class PlayxUpdateOptions {
     this.localVersion,
     this.newVersion,
     this.minVersion,
+    this.newPlatformVersion,
+    this.minPlatformVersion,
     this.forceUpdate,
     this.androidPackageName,
     this.iosBundleId,

--- a/lib/src/core/model/playx_platform_version.dart
+++ b/lib/src/core/model/playx_platform_version.dart
@@ -1,0 +1,30 @@
+class PlayxPlatformVersion {
+  final String? android;
+  final String? ios;
+
+  const PlayxPlatformVersion({
+    this.android,
+    this.ios,
+  });
+
+  String? forCurrentPlatform({required bool isAndroid}) {
+    return isAndroid ? android : ios;
+  }
+
+  @override
+  String toString() {
+    return 'PlayxPlatformVersion{android: $android, ios: $ios}';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is PlayxPlatformVersion &&
+        other.android == android &&
+        other.ios == ios;
+  }
+
+  @override
+  int get hashCode => android.hashCode ^ ios.hashCode;
+}

--- a/lib/src/core/model/playx_version_update_info.dart
+++ b/lib/src/core/model/playx_version_update_info.dart
@@ -1,3 +1,5 @@
+import 'package:playx_version_update/src/core/model/playx_platform_version.dart';
+
 /// Represents comprehensive information about the app's version update status.
 ///
 /// This class is typically returned by methods like [PlayxVersionUpdate.checkVersion]
@@ -40,6 +42,12 @@ class PlayxVersionUpdateInfo {
   /// If the [localVersion] is below this [minVersion], then [forceUpdate] will be true.
   final String? minVersion;
 
+  /// Optional: Raw platform-specific new versions provided by the caller.
+  final PlayxPlatformVersion? newPlatformVersion;
+
+  /// Optional: Raw platform-specific minimum versions provided by the caller.
+  final PlayxPlatformVersion? minPlatformVersion;
+
   /// Creates a new instance of [PlayxVersionUpdateInfo].
   const PlayxVersionUpdateInfo({
     required this.localVersion,
@@ -50,13 +58,15 @@ class PlayxVersionUpdateInfo {
     this.country = 'en',
     this.releaseNotes,
     this.minVersion,
+    this.newPlatformVersion,
+    this.minPlatformVersion,
   });
 
   /// Returns a string representation of the [PlayxVersionUpdateInfo] instance,
   /// useful for debugging.
   @override
   String toString() {
-    return 'PlayxVersionUpdateInfo{localVersion: $localVersion, newVersion: $newVersion, forceUpdate: $forceUpdate, storeUrl: $storeUrl, country: $country, canUpdate: $canUpdate, releaseNotes: $releaseNotes, minVersion: $minVersion}';
+    return 'PlayxVersionUpdateInfo{localVersion: $localVersion, newVersion: $newVersion, forceUpdate: $forceUpdate, storeUrl: $storeUrl, country: $country, canUpdate: $canUpdate, releaseNotes: $releaseNotes, minVersion: $minVersion, newPlatformVersion: $newPlatformVersion, minPlatformVersion: $minPlatformVersion}';
   }
 
   /// Compares this [PlayxVersionUpdateInfo] instance with [other] for equality.
@@ -74,7 +84,9 @@ class PlayxVersionUpdateInfo {
         other.country == country &&
         other.canUpdate == canUpdate &&
         other.releaseNotes == releaseNotes &&
-        other.minVersion == minVersion;
+        other.minVersion == minVersion &&
+        other.newPlatformVersion == newPlatformVersion &&
+        other.minPlatformVersion == minPlatformVersion;
   }
 
   /// Returns a hash code for this [PlayxVersionUpdateInfo] instance.
@@ -89,6 +101,8 @@ class PlayxVersionUpdateInfo {
         country.hashCode ^
         canUpdate.hashCode ^
         releaseNotes.hashCode ^
-        minVersion.hashCode;
+        minVersion.hashCode ^
+        newPlatformVersion.hashCode ^
+        minPlatformVersion.hashCode;
   }
 }

--- a/lib/src/core/model/store_info.dart
+++ b/lib/src/core/model/store_info.dart
@@ -1,8 +1,15 @@
 import 'dart:convert';
 
 import 'package:playx_version_update/src/core/utils/utils.dart';
+import 'package:playx_version_update/src/core/version_checker/version.dart';
 
 class StoreInfo {
+  static final RegExp _versionStartsWithNumberRegexp = RegExp(r'^\d');
+  static final RegExp _minimumVersionRegexp = RegExp(
+    r'\[\s*minimum[\s_-]*version\s*[:=]\s*([^\]\r\n]+?)\s*\]',
+    caseSensitive: false,
+  );
+
   final String version;
   final String? minVersion;
   final String? releaseNotes;
@@ -51,19 +58,8 @@ class StoreInfo {
       // Minimum version from description - This regex is kept as is.
       final regexpDescription =
           RegExp(r'\[\[(null,)\"((\.[a-z]+)?(([^"]|\\")*)?)\"\]\]');
-      final description =
-          regexpDescription.firstMatch(body)?.group(2)?.toLowerCase();
-
-      if (description != null && description.isNotEmpty) {
-        final minimumVersionPrefix = '[Minimum Version :'.toLowerCase();
-        if (description.contains(minimumVersionPrefix)) {
-          minVersion = description
-              .substring(description.indexOf(minimumVersionPrefix))
-              .split(minimumVersionPrefix)[1]
-              .split(']')[0]
-              .trim();
-        }
-      }
+      final description = regexpDescription.firstMatch(body)?.group(2);
+      minVersion = extractMinVersion(description);
     } catch (_) {
       // Error handling for minVersion extraction is already present.
     }
@@ -88,17 +84,7 @@ class StoreInfo {
       String? minVersion;
 
       final description = jsonObj['results'][0]['description'];
-
-      if (description != null && description.isNotEmpty) {
-        final minimumVersionPrefix = '[Minimum Version :'.toLowerCase();
-        if (description.contains(minimumVersionPrefix)) {
-          minVersion = description
-              .substring(description.indexOf(minimumVersionPrefix))
-              .split(minimumVersionPrefix)[1]
-              .split(']')[0]
-              .trim();
-        }
-      }
+      minVersion = extractMinVersion(description);
       return StoreInfo(
         version: storeVersion ?? '',
         minVersion: minVersion,
@@ -107,6 +93,22 @@ class StoreInfo {
       );
     } catch (_) {
       throw Exception('Not found');
+    }
+  }
+
+  static String? extractMinVersion(dynamic description) {
+    if (description is! String || description.trim().isEmpty) return null;
+
+    final candidate =
+        _minimumVersionRegexp.firstMatch(description)?.group(1)?.trim();
+    if (candidate == null || candidate.isEmpty) return null;
+    if (!_versionStartsWithNumberRegexp.hasMatch(candidate)) return null;
+
+    try {
+      Version.parse(candidate);
+      return candidate;
+    } catch (_) {
+      return null;
     }
   }
 

--- a/lib/src/core/utils/utils.dart
+++ b/lib/src/core/utils/utils.dart
@@ -10,12 +10,25 @@ String? getFormattedHtmlText(
       )
       .replaceAll(
         "<p>",
+        "",
+      )
+      .replaceAll(
+        "</p>",
         "\n\n",
       )
       .replaceAll(
         "<br>",
         "\n",
       )
+      .replaceAll(
+        "<br/>",
+        "\n",
+      )
+      .replaceAll(
+        "<br />",
+        "\n",
+      )
+      .replaceAll(RegExp(r'<[^>]*>'), ' ')
       .replaceAll(
         "&quot;",
         "\"",
@@ -26,20 +39,16 @@ String? getFormattedHtmlText(
       )
       .replaceAll(
         "&lt;",
+        "<",
+      )
+      .replaceAll(
+        "&gt;",
         ">",
-      )
-      .replaceAll(
-        "&gt;",
-        "<",
-      )
-      .replaceAll(
-        "&gt;",
-        "<",
       )
       .replaceAll(
         "&#39;",
         "'",
       )
-      .replaceAll(RegExp(r'<[^>]*>|&[^;]+;'), ' ')
+      .replaceAll(RegExp(r'&[^;]+;'), ' ')
       .trim();
 }

--- a/lib/src/core/version_checker/version_checker.dart
+++ b/lib/src/core/version_checker/version_checker.dart
@@ -3,12 +3,23 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:playx_version_update/src/core/datasource/remote_store_data_source.dart';
+import 'package:playx_version_update/src/core/model/playx_platform_version.dart';
 import 'package:playx_version_update/src/core/model/playx_version_update_info.dart';
 import 'package:playx_version_update/src/core/model/result/playx_version_update_error.dart';
 import 'package:playx_version_update/src/core/model/result/playx_version_update_result.dart';
 import 'package:playx_version_update/src/core/version_checker/version.dart';
 
 import '../model/options/playx_update_options.dart';
+
+String? resolvePlatformVersionForCurrentPlatform({
+  required bool isAndroid,
+  required String? genericVersion,
+  required PlayxPlatformVersion? platformVersion,
+}) {
+  final version = platformVersion?.forCurrentPlatform(isAndroid: isAndroid);
+  if (version == null || version.isEmpty) return genericVersion;
+  return version;
+}
 
 class VersionChecker {
   static final VersionChecker _instance = VersionChecker._internal();
@@ -41,6 +52,9 @@ class VersionChecker {
         country: options.country,
         language: options.language,
         newVersion: options.newVersion,
+        newPlatformVersion: options.newPlatformVersion,
+        minVersion: options.minVersion,
+        minPlatformVersion: options.minPlatformVersion,
         forceUpdate: options.forceUpdate,
         enableLog: options.enableNetworkLogging,
       );
@@ -52,6 +66,9 @@ class VersionChecker {
         country: options.country,
         language: options.language,
         newVersion: options.newVersion,
+        newPlatformVersion: options.newPlatformVersion,
+        minVersion: options.minVersion,
+        minPlatformVersion: options.minPlatformVersion,
         forceUpdate: options.forceUpdate,
         enableLog: options.enableNetworkLogging,
       );
@@ -67,6 +84,9 @@ class VersionChecker {
     required String country,
     required String language,
     required String? newVersion,
+    required PlayxPlatformVersion? newPlatformVersion,
+    required String? minVersion,
+    required PlayxPlatformVersion? minPlatformVersion,
     required bool? forceUpdate,
     bool enableLog = false,
   }) async {
@@ -79,16 +99,26 @@ class VersionChecker {
     return storeInfo.mapAsync(success: (infoResult) async {
       final info = infoResult.data;
 
-      final currentVersion = newVersion ?? info.version;
+      final currentVersion = resolvePlatformVersionForCurrentPlatform(
+            isAndroid: true,
+            genericVersion: newVersion ?? info.version,
+            platformVersion: newPlatformVersion,
+          ) ??
+          '';
       final canUpdateResult = await shouldUpdate(
           version: localVersion, currentVersion: currentVersion);
 
       return canUpdateResult.mapAsync(success: (shouldUpdate) async {
-        final minVersion = await getMinVersionVersion(
-            minVersion: info.minVersion, storeVersion: info.version);
+        final effectiveMinVersion = resolvePlatformVersionForCurrentPlatform(
+          isAndroid: true,
+          genericVersion: minVersion ?? info.minVersion,
+          platformVersion: minPlatformVersion,
+        );
+        final normalizedMinVersion = await getMinVersionVersion(
+            minVersion: effectiveMinVersion, storeVersion: currentVersion);
         bool shouldAppForcedToUpdate = await shouldForceUpdate(
             version: localVersion,
-            minVersion: minVersion,
+            minVersion: normalizedMinVersion,
             playxForceUpdate: forceUpdate);
 
         final updateInfo = PlayxVersionUpdateInfo(
@@ -100,7 +130,9 @@ class VersionChecker {
           canUpdate: shouldUpdate,
           forceUpdate: shouldAppForcedToUpdate,
           releaseNotes: info.releaseNotes,
-          minVersion: minVersion,
+          minVersion: normalizedMinVersion,
+          newPlatformVersion: newPlatformVersion,
+          minPlatformVersion: minPlatformVersion,
         );
 
         return PlayxVersionUpdateResult.success(updateInfo);
@@ -119,6 +151,9 @@ class VersionChecker {
     required String country,
     required String language,
     required String? newVersion,
+    required PlayxPlatformVersion? newPlatformVersion,
+    required String? minVersion,
+    required PlayxPlatformVersion? minPlatformVersion,
     required bool? forceUpdate,
     bool enableLog = false,
   }) async {
@@ -131,16 +166,26 @@ class VersionChecker {
     return storeInfo.mapAsync(success: (infoResult) async {
       final info = infoResult.data;
 
-      final currentVersion = newVersion ?? info.version;
+      final currentVersion = resolvePlatformVersionForCurrentPlatform(
+            isAndroid: false,
+            genericVersion: newVersion ?? info.version,
+            platformVersion: newPlatformVersion,
+          ) ??
+          '';
       final canUpdateResult = await shouldUpdate(
           version: localVersion, currentVersion: currentVersion);
 
       return canUpdateResult.mapAsync(success: (shouldUpdate) async {
-        final minVersion = await getMinVersionVersion(
-            minVersion: info.minVersion, storeVersion: info.version);
+        final effectiveMinVersion = resolvePlatformVersionForCurrentPlatform(
+          isAndroid: false,
+          genericVersion: minVersion ?? info.minVersion,
+          platformVersion: minPlatformVersion,
+        );
+        final normalizedMinVersion = await getMinVersionVersion(
+            minVersion: effectiveMinVersion, storeVersion: currentVersion);
         bool shouldAppForcedToUpdate = await shouldForceUpdate(
             version: localVersion,
-            minVersion: minVersion,
+            minVersion: normalizedMinVersion,
             playxForceUpdate: forceUpdate);
 
         final updateInfo = PlayxVersionUpdateInfo(
@@ -151,7 +196,9 @@ class VersionChecker {
           canUpdate: shouldUpdate,
           forceUpdate: shouldAppForcedToUpdate,
           releaseNotes: info.releaseNotes,
-          minVersion: minVersion,
+          minVersion: normalizedMinVersion,
+          newPlatformVersion: newPlatformVersion,
+          minPlatformVersion: minPlatformVersion,
         );
 
         return PlayxVersionUpdateResult.success(updateInfo);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: playx_version_update
 description: Easily show material update dialog in Android or Cupertino dialog in IOS with support for Google play in app updates.
-version: 1.2.0
+version: 1.3.0
 homepage: https://sourcya.io
 repository: https://github.com/playx-flutter/playx_version_update
 issue_tracker: https://github.com/playx-flutter/playx_version_update/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: playx_version_update
 description: Easily show material update dialog in Android or Cupertino dialog in IOS with support for Google play in app updates.
-version: 1.1.0
+version: 1.2.0
 homepage: https://sourcya.io
 repository: https://github.com/playx-flutter/playx_version_update
 issue_tracker: https://github.com/playx-flutter/playx_version_update/issues

--- a/test/core/datasource/remote_store_data_source_test.dart
+++ b/test/core/datasource/remote_store_data_source_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playx_version_update/src/core/datasource/remote_store_data_source.dart';
+
+void main() {
+  group('store urls', () {
+    test('builds google play url', () {
+      expect(
+        getGooglePlayUrl(
+          packageId: 'com.example.app',
+          country: 'us',
+          language: 'en',
+        ),
+        'https://play.google.com/store/apps/details?id=com.example.app&hl=en&gl=us',
+      );
+    });
+
+    test('builds app store lookup url', () {
+      expect(
+        getAppStoreInfoUrl(
+          packageId: 'com.example.app',
+          country: 'in',
+          language: 'en',
+        ),
+        'https://itunes.apple.com/lookup?bundleId=com.example.app&country=in&lang=en',
+      );
+    });
+  });
+}

--- a/test/core/model/playx_platform_version_test.dart
+++ b/test/core/model/playx_platform_version_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playx_version_update/src/core/model/playx_platform_version.dart';
+
+void main() {
+  group('PlayxPlatformVersion', () {
+    const version = PlayxPlatformVersion(
+      android: '2.0.0',
+      ios: '3.0.0',
+    );
+
+    test('returns the correct value for the current platform', () {
+      expect(version.forCurrentPlatform(isAndroid: true), '2.0.0');
+      expect(version.forCurrentPlatform(isAndroid: false), '3.0.0');
+    });
+
+    test('supports equality, hashCode, and toString', () {
+      const same = PlayxPlatformVersion(
+        android: '2.0.0',
+        ios: '3.0.0',
+      );
+
+      expect(version, same);
+      expect(version.hashCode, same.hashCode);
+      expect(version.toString(), contains('android: 2.0.0'));
+      expect(version.toString(), contains('ios: 3.0.0'));
+    });
+  });
+}

--- a/test/core/model/result/playx_version_update_error_test.dart
+++ b/test/core/model/result/playx_version_update_error_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playx_version_update/src/core/model/result/playx_version_update_error.dart';
+
+void main() {
+  group('PlayxVersionUpdateError.fromInAppUpdateErrorCode', () {
+    test('maps general known error codes', () {
+      expect(
+        PlayxVersionUpdateError.fromInAppUpdateErrorCode(
+          'ACTIVITY_NOT_FOUND',
+          'ignored',
+        ),
+        isA<ActivityNotFoundError>(),
+      );
+      expect(
+        PlayxVersionUpdateError.fromInAppUpdateErrorCode(
+          'APP_UPDATE_MANGER_NOT_FOUND',
+          'ignored',
+        ),
+        isA<AppUpdateMangerNotFoundError>(),
+      );
+      expect(
+        PlayxVersionUpdateError.fromInAppUpdateErrorCode(
+          'PLAYX_INFO_REQUEST_CANCELLED',
+          'ignored',
+        ),
+        isA<PlayxInAppUpdateCanceledError>(),
+      );
+      expect(
+        PlayxVersionUpdateError.fromInAppUpdateErrorCode(
+          'PLAYX_UPDATE_CANCELLED',
+          'ignored',
+        ),
+        isA<PlayxInAppUpdateCanceledError>(),
+      );
+      expect(
+        PlayxVersionUpdateError.fromInAppUpdateErrorCode(
+          'PLAYX_IN_APP_UPDATE_FAILED',
+          'ignored',
+        ),
+        isA<PlayxInAppUpdateFailedError>(),
+      );
+      expect(
+        PlayxVersionUpdateError.fromInAppUpdateErrorCode(
+          'PLATFORM_NOT_SUPPORTED_ERROR',
+          'ignored',
+        ),
+        isA<PlatformNotSupportedError>(),
+      );
+    });
+
+    test('maps install-prefixed codes to install errors', () {
+      expect(
+        PlayxVersionUpdateError.fromInAppUpdateErrorCode(
+          'INSTALL_API_NOT_AVAILABLE',
+          'ignored',
+        ),
+        isA<InstallApiNotAvailableError>(),
+      );
+      expect(
+        PlayxVersionUpdateError.fromInAppUpdateErrorCode(
+          'INSTALL_DOWNLOAD_NOT_PRESENT',
+          'ignored',
+        ),
+        isA<InstallDownloadNotPresentError>(),
+      );
+      expect(
+        PlayxVersionUpdateError.fromInAppUpdateErrorCode(
+          'INSTALL_UNKNOWN_ERROR',
+          'custom message',
+        ),
+        isA<InstallUnknownError>(),
+      );
+    });
+
+    test('falls back to default failure for unknown non-install codes', () {
+      final error = PlayxVersionUpdateError.fromInAppUpdateErrorCode(
+        'SOMETHING_NEW',
+        'custom message',
+      );
+
+      expect(error, isA<DefaultFailureError>());
+      expect(error.errorCode, 'DEFAULT_FAILURE_ERROR');
+      expect(error.message, 'custom message');
+    });
+  });
+
+  group('DefaultFailureError', () {
+    test('uses fallback message when no message is provided', () {
+      const error = DefaultFailureError();
+
+      expect(error.errorCode, 'DEFAULT_FAILURE_ERROR');
+      expect(error.message, 'An unknown error occurred. Please try again.');
+    });
+  });
+
+  group('PlayxVersionCantUpdateError', () {
+    test('includes both versions in the message', () {
+      const error = PlayxVersionCantUpdateError(
+        currentVersion: '2.0.0',
+        newVersion: '1.0.0',
+      );
+
+      expect(error.errorCode, 'PLAYX_VERSION_CANT_UPDATE_ERROR_CODE');
+      expect(error.message, contains('2.0.0'));
+      expect(error.message, contains('1.0.0'));
+    });
+  });
+}

--- a/test/core/model/result/playx_version_update_result_test.dart
+++ b/test/core/model/result/playx_version_update_result_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:playx_version_update/src/core/model/playx_platform_version.dart';
+import 'package:playx_version_update/src/core/model/playx_version_update_info.dart';
 import 'package:playx_version_update/src/core/model/result/playx_version_update_error.dart';
 import 'package:playx_version_update/src/core/model/result/playx_version_update_result.dart';
 
@@ -85,6 +87,45 @@ void main() {
 
       expect(mapped.isError, isTrue);
       expect(mapped.updateError, isA<DefaultFailureError>());
+    });
+  });
+
+  group('PlayxVersionUpdateInfo with platform versions', () {
+    test(
+        'preserves raw platform versions while keeping effective generic fields',
+        () {
+      const newPlatformVersion = PlayxPlatformVersion(
+        android: '2.0.0',
+        ios: '3.0.0',
+      );
+      const minPlatformVersion = PlayxPlatformVersion(
+        android: '1.5.0',
+        ios: '2.5.0',
+      );
+
+      const info = PlayxVersionUpdateInfo(
+        localVersion: '1.0.0',
+        newVersion: '2.0.0',
+        canUpdate: true,
+        forceUpdate: true,
+        storeUrl: 'https://example.com',
+        minVersion: '1.5.0',
+        newPlatformVersion: newPlatformVersion,
+        minPlatformVersion: minPlatformVersion,
+      );
+
+      expect(info.newVersion, '2.0.0');
+      expect(info.minVersion, '1.5.0');
+      expect(info.newPlatformVersion, newPlatformVersion);
+      expect(info.minPlatformVersion, minPlatformVersion);
+      expect(
+        info.toString(),
+        contains('newPlatformVersion: $newPlatformVersion'),
+      );
+      expect(
+        info.toString(),
+        contains('minPlatformVersion: $minPlatformVersion'),
+      );
     });
   });
 }

--- a/test/core/model/result/playx_version_update_result_test.dart
+++ b/test/core/model/result/playx_version_update_result_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playx_version_update/src/core/model/result/playx_version_update_error.dart';
+import 'package:playx_version_update/src/core/model/result/playx_version_update_result.dart';
+
+void main() {
+  group('PlayxVersionUpdateResult success', () {
+    const result = PlayxVersionUpdateResult<int>.success(42);
+
+    test('exposes success state and updateData', () {
+      expect(result.isSuccess, isTrue);
+      expect(result.isError, isFalse);
+      expect(result.updateData, 42);
+      expect(result.updateError, isNull);
+    });
+
+    test('when invokes success callback', () {
+      final message = result.when(
+        success: (data) => 'ok:$data',
+        error: (error) => 'error:${error.errorCode}',
+      );
+
+      expect(message, 'ok:42');
+    });
+
+    test('map transforms success values', () {
+      final mapped = result.map<String>(
+        success: (data) => PlayxVersionUpdateResult.success('value:$data'),
+        error: PlayxVersionUpdateResult.error,
+      );
+
+      expect(mapped.isSuccess, isTrue);
+      expect(mapped.updateData, 'value:42');
+    });
+
+    test('mapAsync transforms success values', () async {
+      final mapped = await result.mapAsync<String>(
+        success: (data) async =>
+            PlayxVersionUpdateResult.success('value:$data'),
+        error: (error) async => PlayxVersionUpdateResult.error(error),
+      );
+
+      expect(mapped.isSuccess, isTrue);
+      expect(mapped.updateData, 'value:42');
+    });
+  });
+
+  group('PlayxVersionUpdateResult error', () {
+    final result = PlayxVersionUpdateResult<int>.error(
+      const DefaultFailureError(errorMsg: 'failed'),
+    );
+
+    test('exposes error state and updateError', () {
+      expect(result.isSuccess, isFalse);
+      expect(result.isError, isTrue);
+      expect(result.updateData, isNull);
+      expect(result.updateError, isA<DefaultFailureError>());
+      expect(result.updateError?.message, 'failed');
+    });
+
+    test('when invokes error callback', () {
+      final message = result.when(
+        success: (data) => 'ok:$data',
+        error: (error) => 'error:${error.errorCode}',
+      );
+
+      expect(message, 'error:DEFAULT_FAILURE_ERROR');
+    });
+
+    test('map preserves error values', () {
+      final mapped = result.map<String>(
+        success: (data) => PlayxVersionUpdateResult.success('value:$data'),
+        error: PlayxVersionUpdateResult.error,
+      );
+
+      expect(mapped.isError, isTrue);
+      expect(mapped.updateError, isA<DefaultFailureError>());
+    });
+
+    test('mapAsync preserves error values', () async {
+      final mapped = await result.mapAsync<String>(
+        success: (data) async =>
+            PlayxVersionUpdateResult.success('value:$data'),
+        error: (error) async => PlayxVersionUpdateResult.error(error),
+      );
+
+      expect(mapped.isError, isTrue);
+      expect(mapped.updateError, isA<DefaultFailureError>());
+    });
+  });
+}

--- a/test/core/model/store_info_test.dart
+++ b/test/core/model/store_info_test.dart
@@ -15,16 +15,6 @@ void main() {
         '1.2.0',
       );
     });
-    test('parses the original2 bracketed format case-insensitively', () {
-      expect(
-        StoreInfo.extractMinVersion('[ Minimum Version : 1.2 ]'),
-        '1.2',
-      );
-      expect(
-        StoreInfo.extractMinVersion('[minimum version :1.2.0]'),
-        '1.2.0',
-      );
-    });
 
     test('supports common separator and spacing variants', () {
       expect(

--- a/test/core/utils/utils_test.dart
+++ b/test/core/utils/utils_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playx_version_update/src/core/utils/utils.dart';
+
+void main() {
+  group('getFormattedHtmlText', () {
+    test('returns null when input is null', () {
+      expect(getFormattedHtmlText(null), isNull);
+    });
+
+    test('decodes unicode escapes and common html entities', () {
+      expect(
+        getFormattedHtmlText(r'Hello \u0041 &quot;World&quot; &apos;test&#39;'),
+        'Hello A "World" \'test\'',
+      );
+    });
+
+    test('converts paragraph and line-break tags into newlines', () {
+      expect(
+        getFormattedHtmlText('<p>Line 1</p><br>Line 2'),
+        'Line 1\n\n\nLine 2',
+      );
+    });
+
+    test('preserves lt and gt direction correctly', () {
+      expect(
+        getFormattedHtmlText('Use &lt;tag&gt; here'),
+        'Use <tag> here',
+      );
+    });
+
+    test('strips remaining tags and unknown entities', () {
+      expect(
+        getFormattedHtmlText('<div>Hello&nbsp;<strong>world</strong></div>'),
+        'Hello  world',
+      );
+    });
+  });
+}

--- a/test/core/version_checker/version_checker_test.dart
+++ b/test/core/version_checker/version_checker_test.dart
@@ -1,0 +1,234 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playx_version_update/src/core/model/result/playx_version_update_error.dart';
+import 'package:playx_version_update/src/core/version_checker/version_checker.dart';
+
+void main() {
+  final checker = VersionChecker();
+
+  group('VersionChecker.getMinVersionVersion', () {
+    test('returns null for missing minimum version', () async {
+      expect(
+        await checker.getMinVersionVersion(
+          minVersion: null,
+          storeVersion: '1.2.3',
+        ),
+        isNull,
+      );
+      expect(
+        await checker.getMinVersionVersion(
+          minVersion: '',
+          storeVersion: '1.2.3',
+        ),
+        isNull,
+      );
+    });
+
+    test('uses the parser behavior for permissive minimum version strings',
+        () async {
+      expect(
+        await checker.getMinVersionVersion(
+          minVersion: 'not-a-version',
+          storeVersion: '1.2.3',
+        ),
+        '0.0.0-a-version',
+      );
+      expect(
+        await checker.getMinVersionVersion(
+          minVersion: '1.2.3+build?1',
+          storeVersion: null,
+        ),
+        '1.2.0',
+      );
+    });
+
+    test('normalizes parsed minimum version', () async {
+      expect(
+        await checker.getMinVersionVersion(
+          minVersion: '1.2',
+          storeVersion: null,
+        ),
+        '1.2.0',
+      );
+      expect(
+        await checker.getMinVersionVersion(
+          minVersion: '3.122.764106578.release',
+          storeVersion: null,
+        ),
+        '3.122.764106578',
+      );
+    });
+
+    test('clamps minimum version to store version when needed', () async {
+      expect(
+        await checker.getMinVersionVersion(
+          minVersion: '2.0.0',
+          storeVersion: '1.5.0',
+        ),
+        '1.5.0',
+      );
+      expect(
+        await checker.getMinVersionVersion(
+          minVersion: '1.2.3.9',
+          storeVersion: '1.2.3.4',
+        ),
+        '1.2.3.4',
+      );
+    });
+
+    test('keeps the minimum version when it is below the store version',
+        () async {
+      expect(
+        await checker.getMinVersionVersion(
+          minVersion: '1.2.3-alpha.1',
+          storeVersion: '1.2.3',
+        ),
+        '1.2.3-alpha.1',
+      );
+    });
+  });
+
+  group('VersionChecker.shouldForceUpdate', () {
+    test('respects explicit override first', () async {
+      expect(
+        await checker.shouldForceUpdate(
+          version: '1.0.0',
+          minVersion: '9.0.0',
+          playxForceUpdate: false,
+        ),
+        isFalse,
+      );
+      expect(
+        await checker.shouldForceUpdate(
+          version: '9.0.0',
+          minVersion: null,
+          playxForceUpdate: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('returns false when minimum version is missing or truly invalid',
+        () async {
+      expect(
+        await checker.shouldForceUpdate(
+          version: '1.0.0',
+          minVersion: null,
+          playxForceUpdate: null,
+        ),
+        isFalse,
+      );
+      expect(
+        await checker.shouldForceUpdate(
+          version: '1.0.0',
+          minVersion: '1.2.3-alpha..1',
+          playxForceUpdate: null,
+        ),
+        isFalse,
+      );
+    });
+
+    test('forces update when local version is equal to or below minimum',
+        () async {
+      expect(
+        await checker.shouldForceUpdate(
+          version: '1.2.2',
+          minVersion: '1.2.3',
+          playxForceUpdate: null,
+        ),
+        isTrue,
+      );
+      expect(
+        await checker.shouldForceUpdate(
+          version: '1.2.3',
+          minVersion: '1.2.3',
+          playxForceUpdate: null,
+        ),
+        isTrue,
+      );
+      expect(
+        await checker.shouldForceUpdate(
+          version: '1.2.3-alpha.1',
+          minVersion: '1.2.3',
+          playxForceUpdate: null,
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not force update when local version is above minimum', () async {
+      expect(
+        await checker.shouldForceUpdate(
+          version: '1.2.4',
+          minVersion: '1.2.3',
+          playxForceUpdate: null,
+        ),
+        isFalse,
+      );
+      expect(
+        await checker.shouldForceUpdate(
+          version: '1.2.3.5',
+          minVersion: '1.2.3.4',
+          playxForceUpdate: null,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('VersionChecker.shouldUpdate', () {
+    test('returns success true only when current version is newer', () async {
+      final newer = await checker.shouldUpdate(
+        version: '1.2.3',
+        currentVersion: '1.2.4',
+      );
+      final equal = await checker.shouldUpdate(
+        version: '1.2.3',
+        currentVersion: '1.2.3',
+      );
+      final older = await checker.shouldUpdate(
+        version: '1.2.4',
+        currentVersion: '1.2.3',
+      );
+
+      expect(newer.isSuccess, isTrue);
+      expect(newer.updateData, isTrue);
+      expect(equal.updateData, isFalse);
+      expect(older.updateData, isFalse);
+    });
+
+    test('handles additional segments and pre-release precedence', () async {
+      final additional = await checker.shouldUpdate(
+        version: '1.2.3.4',
+        currentVersion: '1.2.3.5',
+      );
+      final preRelease = await checker.shouldUpdate(
+        version: '1.2.3-alpha.1',
+        currentVersion: '1.2.3',
+      );
+
+      expect(additional.updateData, isTrue);
+      expect(preRelease.updateData, isTrue);
+    });
+
+    test('returns VersionFormatException for empty current version', () async {
+      final result = await checker.shouldUpdate(
+        version: '1.2.3',
+        currentVersion: '',
+      );
+
+      expect(result.isError, isTrue);
+      expect(result.updateError, isA<VersionFormatException>());
+    });
+
+    test('returns VersionFormatException for truly malformed current version',
+        () async {
+      final result = await checker.shouldUpdate(
+        version: '1.2.3',
+        currentVersion: '1.2.3-alpha..1',
+      );
+
+      expect(result.isError, isTrue);
+      expect(result.updateError, isA<VersionFormatException>());
+    });
+  });
+}

--- a/test/core/version_checker/version_checker_test.dart
+++ b/test/core/version_checker/version_checker_test.dart
@@ -1,9 +1,69 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:playx_version_update/src/core/model/playx_platform_version.dart';
 import 'package:playx_version_update/src/core/model/result/playx_version_update_error.dart';
 import 'package:playx_version_update/src/core/version_checker/version_checker.dart';
 
 void main() {
   final checker = VersionChecker();
+
+  group('resolvePlatformVersionForCurrentPlatform', () {
+    test('prefers current platform-specific value over the generic version',
+        () {
+      const platformVersion = PlayxPlatformVersion(
+        android: '2.0.0',
+        ios: '3.0.0',
+      );
+
+      expect(
+        resolvePlatformVersionForCurrentPlatform(
+          isAndroid: true,
+          genericVersion: '1.0.0',
+          platformVersion: platformVersion,
+        ),
+        '2.0.0',
+      );
+      expect(
+        resolvePlatformVersionForCurrentPlatform(
+          isAndroid: false,
+          genericVersion: '1.0.0',
+          platformVersion: platformVersion,
+        ),
+        '3.0.0',
+      );
+    });
+
+    test(
+        'falls back to the generic version when current platform value is missing',
+        () {
+      expect(
+        resolvePlatformVersionForCurrentPlatform(
+          isAndroid: true,
+          genericVersion: '1.0.0',
+          platformVersion: const PlayxPlatformVersion(ios: '3.0.0'),
+        ),
+        '1.0.0',
+      );
+      expect(
+        resolvePlatformVersionForCurrentPlatform(
+          isAndroid: false,
+          genericVersion: '1.0.0',
+          platformVersion: const PlayxPlatformVersion(android: '2.0.0'),
+        ),
+        '1.0.0',
+      );
+    });
+
+    test('returns the generic version when no platform object is provided', () {
+      expect(
+        resolvePlatformVersionForCurrentPlatform(
+          isAndroid: true,
+          genericVersion: '1.0.0',
+          platformVersion: null,
+        ),
+        '1.0.0',
+      );
+    });
+  });
 
   group('VersionChecker.getMinVersionVersion', () {
     test('returns null for missing minimum version', () async {
@@ -72,6 +132,13 @@ void main() {
           storeVersion: '1.2.3.4',
         ),
         '1.2.3.4',
+      );
+      expect(
+        await checker.getMinVersionVersion(
+          minVersion: '9.0.0',
+          storeVersion: '2.0.0',
+        ),
+        '2.0.0',
       );
     });
 

--- a/test/core/version_checker/version_test.dart
+++ b/test/core/version_checker/version_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playx_version_update/src/core/version_checker/version.dart';
+
+void main() {
+  group('Version.parse', () {
+    test('parses standard semver with pre-release and build metadata', () {
+      final version = Version.parse('1.2.3-alpha.1+build.456');
+
+      expect(version.major, 1);
+      expect(version.minor, 2);
+      expect(version.patch, 3);
+      expect(version.additionalComponents, isEmpty);
+      expect(version.preRelease, 'alpha.1');
+      expect(version.build, 'build.456');
+      expect(version.toString(), '1.2.3-alpha.1+build.456');
+    });
+
+    test('normalizes missing numeric parts to zero', () {
+      expect(Version.parse('1').toString(), '1.0.0');
+      expect(Version.parse('1.2').toString(), '1.2.0');
+    });
+
+    test('supports additional numeric components', () {
+      final version = Version.parse('519.0.0.44.92');
+
+      expect(version.major, 519);
+      expect(version.minor, 0);
+      expect(version.patch, 0);
+      expect(version.additionalComponents, [44, 92]);
+      expect(version.toString(), '519.0.0.44.92');
+    });
+
+    test('ignores non-numeric core tags after numeric segments', () {
+      final version = Version.parse('3.122.764106578.release');
+
+      expect(version.major, 3);
+      expect(version.minor, 122);
+      expect(version.patch, 764106578);
+      expect(version.additionalComponents, isEmpty);
+      expect(version.preRelease, isEmpty);
+      expect(version.build, isEmpty);
+      expect(version.toString(), '3.122.764106578');
+    });
+
+    test('trims nothing and throws on empty input', () {
+      expect(() => Version.parse(''), throwsFormatException);
+      expect(() => Version.parse('   '), throwsFormatException);
+    });
+
+    test('rejects malformed pre-release metadata', () {
+      expect(() => Version.parse('1.2.3-alpha..1'), throwsArgumentError);
+    });
+
+    test('remains permissive for non-numeric suffix noise in the core string',
+        () {
+      expect(Version.parse('1.2.3+build?1').toString(), '1.2.0');
+      expect(Version.parse('not-a-version').toString(), '0.0.0-a-version');
+    });
+  });
+
+  group('Version.tryParse', () {
+    test('returns null only for inputs the parser truly rejects', () {
+      expect(Version.tryParse(''), isNull);
+      expect(Version.tryParse('1.2.3-alpha..1'), isNull);
+    });
+
+    test('keeps permissive parsing behavior for noisy inputs', () {
+      expect(Version.tryParse('1.2.3+build?1')?.toString(), '1.2.0');
+      expect(Version.tryParse('not-a-version')?.toString(), '0.0.0-a-version');
+    });
+  });
+
+  group('Version comparison', () {
+    test('compares additional numeric components', () {
+      expect(Version.parse('1.2.3.4') > Version.parse('1.2.3'), isTrue);
+      expect(Version.parse('1.2.3.4') < Version.parse('1.2.3.5'), isTrue);
+      expect(Version.parse('1.2.3.0'), Version.parse('1.2.3'));
+    });
+
+    test('follows pre-release precedence rules implemented by the parser', () {
+      expect(Version.parse('1.2.3-alpha') < Version.parse('1.2.3'), isTrue);
+      expect(Version.parse('1.2.3-alpha.1') < Version.parse('1.2.3-alpha.beta'),
+          isTrue);
+      expect(Version.parse('1.2.3-alpha.2') > Version.parse('1.2.3-alpha.1'),
+          isTrue);
+      expect(Version.parse('1.2.3-alpha.beta') > Version.parse('1.2.3-alpha.1'),
+          isTrue);
+    });
+
+    test('ignores build metadata when comparing precedence', () {
+      expect(Version.parse('1.2.3+1'), Version.parse('1.2.3+2'));
+      expect(Version.parse('1.2.3-alpha+1'), Version.parse('1.2.3-alpha+99'));
+    });
+  });
+
+  group('Version increment helpers', () {
+    test('increment major, minor, and patch reset lower-order parts', () {
+      expect(
+        Version.parse('1.2.3.4-alpha+9').incrementMajor().toString(),
+        '2.0.0',
+      );
+      expect(
+        Version.parse('1.2.3.4-alpha+9').incrementMinor().toString(),
+        '1.3.0',
+      );
+      expect(
+        Version.parse('1.2.3.4-alpha+9').incrementPatch().toString(),
+        '1.2.4',
+      );
+    });
+
+    test('incrementPreRelease updates the right-most numeric segment', () {
+      expect(
+        Version.parse('1.2.3-alpha.1').incrementPreRelease().toString(),
+        '1.2.3-alpha.2',
+      );
+      expect(
+        Version.parse('1.2.3-alpha').incrementPreRelease().toString(),
+        '1.2.3-alpha.1',
+      );
+    });
+
+    test('incrementPreRelease rejects stable versions', () {
+      expect(
+        () => Version.parse('1.2.3').incrementPreRelease(),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/test/store_info_test.dart
+++ b/test/store_info_test.dart
@@ -1,0 +1,127 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:playx_version_update/src/core/model/store_info.dart';
+
+void main() {
+  group('StoreInfo.extractMinVersion', () {
+    test('parses the original bracketed format case-insensitively', () {
+      expect(
+        StoreInfo.extractMinVersion('[Minimum Version :1.2.0]'),
+        '1.2.0',
+      );
+      expect(
+        StoreInfo.extractMinVersion('[minimum version :1.2.0]'),
+        '1.2.0',
+      );
+    });
+    test('parses the original2 bracketed format case-insensitively', () {
+      expect(
+        StoreInfo.extractMinVersion('[ Minimum Version : 1.2 ]'),
+        '1.2',
+      );
+      expect(
+        StoreInfo.extractMinVersion('[minimum version :1.2.0]'),
+        '1.2.0',
+      );
+    });
+
+    test('supports common separator and spacing variants', () {
+      expect(
+        StoreInfo.extractMinVersion('[Minimum Version: 1.2.0]'),
+        '1.2.0',
+      );
+      expect(
+        StoreInfo.extractMinVersion('[Minimum Version = 1.2.0]'),
+        '1.2.0',
+      );
+      expect(
+        StoreInfo.extractMinVersion('[minimum_version:1.2.0-beta.1+45]'),
+        '1.2.0-beta.1+45',
+      );
+      expect(
+        StoreInfo.extractMinVersion('[minimum-version: 2.0]'),
+        '2.0',
+      );
+    });
+
+    test('supports version styles accepted by Version.parse', () {
+      expect(
+        StoreInfo.extractMinVersion('[Minimum Version: 519.0.0.44.92]'),
+        '519.0.0.44.92',
+      );
+      expect(
+        StoreInfo.extractMinVersion(
+          '[Minimum Version: 3.122.764106578.release]',
+        ),
+        '3.122.764106578.release',
+      );
+      expect(
+        StoreInfo.extractMinVersion(
+          '[Minimum Version: 1.2.3-alpha.1+build.456]',
+        ),
+        '1.2.3-alpha.1+build.456',
+      );
+    });
+
+    test('ignores unbracketed text to avoid accidental matches', () {
+      expect(
+        StoreInfo.extractMinVersion('Minimum Version = 1.2.0'),
+        isNull,
+      );
+      expect(
+        StoreInfo.extractMinVersion('Some note minimum_version:1.2.0'),
+        isNull,
+      );
+    });
+
+    test('ignores invalid versions even when bracketed', () {
+      expect(
+        StoreInfo.extractMinVersion('[Minimum Version: not-a-version]'),
+        isNull,
+      );
+    });
+
+    test('returns null when the tag is not present', () {
+      expect(
+        StoreInfo.extractMinVersion('No minimum version tag here'),
+        isNull,
+      );
+    });
+  });
+
+  group('StoreInfo.fromAppStore', () {
+    test('extracts minimum version from iOS description', () {
+      final body = json.encode({
+        'results': [
+          {
+            'version': '1.3.0',
+            'trackViewUrl': 'https://apps.apple.com/app/id123',
+            'releaseNotes': 'Bug fixes',
+            'description': 'Features...\n[Minimum Version :1.3.0]',
+          }
+        ]
+      });
+
+      final info = StoreInfo.fromAppStore(body);
+
+      expect(info.version, '1.3.0');
+      expect(info.minVersion, '1.3.0');
+      expect(info.storeUrl, 'https://apps.apple.com/app/id123');
+    });
+  });
+
+  group('StoreInfo.fromGooglePlay', () {
+    test('extracts minimum version from Google Play description', () {
+      const body = '''
+Current Version</div><span><div><span>1.4.0</span>
+[[null,"Features and fixes [Minimum Version = 1.2.0-beta.1]"]]
+''';
+
+      final info = StoreInfo.fromGooglePlay(body);
+
+      expect(info.version, '1.4.0');
+      expect(info.minVersion, '1.2.0-beta.1');
+    });
+  });
+}


### PR DESCRIPTION
## 1.3.0
- Add `PlayxPlatformVersion` with `newPlatformVersion` and `minPlatformVersion` overrides for Android- and iOS-specific app version checks.
- Keep `newVersion` and `minVersion` as the effective resolved values in `PlayxVersionUpdateInfo` for backward compatibility.
- Enhance minimum-version parsing for store descriptions with bracketed, case-insensitive matching and broader version-style support.
- Improve HTML text formatting utilities and expand automated test coverage across version handling, parsing, results, errors, and datasource utilities.
